### PR TITLE
Fix dungeon battle repetition and map display

### DIFF
--- a/newgame/Battle.cs
+++ b/newgame/Battle.cs
@@ -4,7 +4,7 @@
     {
         public Battle()
         {
-            Start();
+            // 생성자에서 전투를 바로 시작하지 않는다.
         }
 
         public void Start()

--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -51,8 +51,6 @@ namespace newgame
                 DrawMap(width, height);
                 DrawPlayer();
 
-                RoomEvent((RoomType)map[playerY][playerX]);
-
                 // 키 입력 받기
                 ConsoleKeyInfo key = Console.ReadKey(true);
 
@@ -71,6 +69,8 @@ namespace newgame
                     playerX = newX;
                     playerY = newY;
                 }
+
+                RoomEvent((RoomType)map[playerY][playerX]);
             }
 
         }
@@ -96,7 +96,7 @@ namespace newgame
         void RoomEvent(RoomType playerRoom)
         {
             RoomType room = (RoomType)map[playerY][playerX];
-            Console.Clear();
+            Console.SetCursorPosition(0, map.Count + 1);
             switch (room)
             {
                 case RoomType.Monster:


### PR DESCRIPTION
## Summary
- prevent Battle from auto-starting twice
- draw dungeon map before reading input and show events after moving

## Testing
- `dotnet build`
- `dotnet run --project newgame` *(fails: missing data files)*

------
https://chatgpt.com/codex/tasks/task_e_68907a0b93dc8330941efc3cb0cec1cc