### PR TITLE
Add reusable skill lookup and simplify skill assignment

### DIFF
--- a/newgame/GameManager.cs
+++ b/newgame/GameManager.cs
@@ -158,6 +158,18 @@ namespace newgame
             }
         }
 
+        public SkillType? FindSkillByName(string name)
+        {
+            foreach (var skill in Skills)
+            {
+                if (skill.GetName == name)
+                {
+                    return skill;
+                }
+            }
+            return null;
+        }
+
         public bool HasSkill(SkillType skill)
         {
             return Skills.Contains(skill);

--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -89,13 +89,10 @@ namespace newgame
         #region 기본스킬 설정
         void SetPlayerStarterSkill()
         {
-            foreach (var skill in GameManager.Instance.GetSkills())
+            var fireball = GameManager.Instance.FindSkillByName("파이어볼");
+            if (fireball != null)
             {
-                if (skill.GetName == "파이어볼")
-                {
-                    skills.Add(skill);
-                    break;
-                }
+                skills.Add(fireball.Value);
             }
         }
         #endregion

--- a/newgame/Skills.cs
+++ b/newgame/Skills.cs
@@ -59,6 +59,14 @@ namespace newgame
         List<SkillType> canUseSkill = new List<SkillType>();
 
         public void AddCanUseSkill(SkillType skills) => canUseSkill.Add(skills);
+        public void AddCanUseSkill(string name)
+        {
+            var skill = GameManager.Instance.FindSkillByName(name);
+            if (skill != null)
+            {
+                canUseSkill.Add(skill.Value);
+            }
+        }
         public void ClearAllCanUseSkills() => canUseSkill.Clear();
 
         public void RemoveCanUseSkill(int idx)


### PR DESCRIPTION
## Summary
- Add `FindSkillByName` utility in `GameManager`
- Use `FindSkillByName` when assigning player starter skill
- Expose overload in `Skills` class to add skill by name

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b840b3196c833085f88cdc3381215c