### PR TITLE
Refactor skill structs to avoid exceptions

### DIFF
--- a/newgame/DataManager.cs
+++ b/newgame/DataManager.cs
@@ -454,7 +454,7 @@ namespace newgame
                     }
                     else if (curLine[0].Trim() == "DURATION")
                     {
-                        skills.skillTrun = int.Parse(curLine[1].Trim());
+                        skills.skillTurn = int.Parse(curLine[1].Trim());
                     }
                 }
             }

--- a/newgame/GameManager.cs
+++ b/newgame/GameManager.cs
@@ -162,7 +162,7 @@ namespace newgame
         {
             foreach (var skill in Skills)
             {
-                if (skill.GetName == name)
+                if (skill.name == name)
                 {
                     return skill;
                 }

--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -97,7 +97,7 @@ namespace newgame
         #endregion
 
         #region 스킬 리스트 표시
-        public int ShowSkillList()
+        public SkillType? ShowSkillList()
         {
             return skillSystem.ShowCanUseSkill();
         }
@@ -126,7 +126,7 @@ namespace newgame
                     }
                 case 1:
                     {
-                        ShowSkillList();
+                        var skill = ShowSkillList();
                         break;
                     }
                 case 2:
@@ -265,7 +265,7 @@ namespace newgame
 
         void BattleSkillLogic()
         {
-            int useSkillNum = ShowSkillList();
+            var useSkill = ShowSkillList();
 
         }
 
@@ -274,3 +274,4 @@ namespace newgame
         #endregion
     }
 }
+

--- a/newgame/Skills.cs
+++ b/newgame/Skills.cs
@@ -1,52 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace newgame
 {
-    public struct SkillType()
+    public struct SkillType
     {
         public string name;
         public int skillId;
         public int skillMana;
         public int skillDamage;
-        public int skillTrun;
-
-        #region Get 프로퍼티
-
-        public string GetName
-        {
-            get => name;
-            private set => name = value;
-        }
-
-        public int GetSkillID
-        {
-            get => skillId;
-            private set => skillId = value;
-        }
-
-        public int GetSkillMana
-        {
-            get => skillMana;
-            private set => skillMana = value;
-        }
-
-        public int GetSkillDamage
-        {
-            get => skillDamage;
-            private set => skillDamage = value;
-        }
-
-        public int GetSkillTurn
-        {
-            get => skillTrun;
-            private set => skillTrun = value;
-        }
-
-        #endregion
+        public int skillTurn;
     }
 
 
@@ -82,32 +45,38 @@ namespace newgame
             Console.WriteLine("해당 번호의 스킬이 존재하지 않습니다.");
         }
 
-        public int ShowCanUseSkill()
+        public SkillType? ShowCanUseSkill()
         {
-            if (canUseSkill == null || canUseSkill.Count == 0)
+            if (canUseSkill.Count == 0)
             {
-                return -1;
+                return null;
             }
 
             List<string> canUseSkillList = new List<string>();
-            string? upType = null;
 
             for (int i = 0; i < canUseSkill.Count; i++)
             {
-                if (canUseSkill[i].GetSkillDamage != 0)
+                var skill = canUseSkill[i];
+                string extra = string.Empty;
+                if (skill.skillDamage != 0)
                 {
-                    upType += $" , 데미지: {canUseSkill[i].GetSkillDamage}";
+                    extra = $" , 데미지: {skill.skillDamage}";
                 }
-                else if (canUseSkill[i].GetSkillTurn != 0)
+                else if (skill.skillTurn != 0)
                 {
-                    upType += $" , 효과 지속 시간: {canUseSkill[i].GetSkillTurn}";
+                    extra = $" , 효과 지속 시간: {skill.skillTurn}";
                 }
 
-                canUseSkillList.Add($"{canUseSkill[i].GetName} --- 마나 사용량 : {canUseSkill[i].GetSkillMana}" + upType);
+                canUseSkillList.Add($"{skill.name} --- 마나 사용량 : {skill.skillMana}{extra}");
             }
 
-            int SelectSkill = UiHelper.SelectMenu(canUseSkillList.ToArray());
-            return SelectSkill;
+            int selected = UiHelper.SelectMenu(canUseSkillList.ToArray());
+            if (selected >= 0 && selected < canUseSkill.Count)
+            {
+                return canUseSkill[selected];
+            }
+
+            return null;
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- simplify `SkillType` struct and remove unused getters
- fix skill list display to avoid null concatenation and accumulation
- update skill loading and lookup for new field names
- return selected `SkillType` instead of index when showing usable skills

## Testing
- `dotnet build newgame.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b95aaad510833098de28debe1d99b3