### PR TITLE
Add basic per-turn skill effect system

### DIFF
--- a/newgame/ActiveSkillEffect.cs
+++ b/newgame/ActiveSkillEffect.cs
@@ -1,0 +1,16 @@
+namespace newgame
+{
+    internal class ActiveSkillEffect
+    {
+        public int SkillId { get; private set; }
+        public int RemainingTurn { get; set; }
+        public int TotalPower { get; set; }
+
+        public ActiveSkillEffect(SkillType skill)
+        {
+            SkillId = skill.skillId;
+            RemainingTurn = skill.skillTurn;
+            TotalPower = skill.skillDamage;
+        }
+    }
+}

--- a/newgame/Character.cs
+++ b/newgame/Character.cs
@@ -14,6 +14,7 @@ namespace newgame
         }
 
         private List<ActiveItemEffect> activeEffects = new();
+        private List<ActiveSkillEffect> activeSkillEffects = new();
 
         public bool IsDead = false;
         public bool isbattleRun = false;
@@ -256,6 +257,49 @@ namespace newgame
             return total;
         }
 
+        #endregion
+
+        #region 스킬 관련 추가
+        public void AddSkillEffect(SkillType skill)
+        {
+            var effect = activeSkillEffects.Find(e => e.SkillId == skill.skillId);
+            if (effect != null)
+            {
+                effect.RemainingTurn = skill.skillTurn;
+                effect.TotalPower += skill.skillDamage;
+            }
+            else
+            {
+                activeSkillEffects.Add(new ActiveSkillEffect(skill));
+            }
+        }
+
+        public void OnSkillTurnPassed()
+        {
+            for (int i = activeSkillEffects.Count - 1; i >= 0; i--)
+            {
+                var effect = activeSkillEffects[i];
+                effect.RemainingTurn--;
+
+                if (effect.RemainingTurn <= 0)
+                {
+                    activeSkillEffects.RemoveAt(i);
+                }
+            }
+        }
+
+        public int GetTotalSkillPower(int skillId)
+        {
+            int total = 0;
+            foreach (var effect in activeSkillEffects)
+            {
+                if (effect.SkillId == skillId)
+                {
+                    total += effect.TotalPower;
+                }
+            }
+            return total;
+        }
         #endregion
     }
 }


### PR DESCRIPTION
## Summary
- add `ActiveSkillEffect` class for tracking persistent skill effects
- extend `Character` to apply and expire skill effects each turn

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bfe34feaf883308844e0068a36324c