### PR TITLE
Switch to dictionary-based skill effects

### DIFF
--- a/newgame/Character.cs
+++ b/newgame/Character.cs
@@ -14,6 +14,9 @@ namespace newgame
         }
 
         private List<ActiveItemEffect> activeEffects = new();
+        protected Dictionary<string, int> activeSkills = new();
+
+        public IReadOnlyDictionary<string, int> ActiveSkills => activeSkills;
 
         public bool IsDead = false;
         public bool isbattleRun = false;
@@ -256,6 +259,28 @@ namespace newgame
             return total;
         }
 
+        #endregion
+
+        #region 스킬 지속 효과
+        public void UseSkill(string skillName, int duration)
+        {
+            activeSkills[skillName] = duration;
+        }
+
+        public void TickSkillTurns()
+        {
+            List<string> expired = new();
+
+            foreach (var kv in activeSkills)
+            {
+                activeSkills[kv.Key]--;
+                if (activeSkills[kv.Key] <= 0)
+                    expired.Add(kv.Key);
+            }
+
+            foreach (var name in expired)
+                activeSkills.Remove(name);
+        }
         #endregion
     }
 }

--- a/newgame/SkillEffectManager.cs
+++ b/newgame/SkillEffectManager.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace newgame
+{
+    internal static class SkillEffectManager
+    {
+        public static void ApplyEffects(Character target)
+        {
+            foreach (var entry in target.ActiveSkills)
+            {
+                switch (entry.Key)
+                {
+                    case "Burn":
+                        target.MyStatus.hp -= 5;
+                        break;
+                    case "Regeneration":
+                        target.MyStatus.hp = Math.Min(target.MyStatus.hp + 3, target.MyStatus.maxHp);
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track active skills with a simple `[name : turn]` dictionary
- overwrite durations when the same skill is applied again
- add `SkillEffectManager` to process skill effects externally

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bfe34feaf883308844e0068a36324c