### PR TITLE
Refine battle message output

### DIFF
--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -190,13 +190,11 @@ namespace newgame
                 case 0:
                     {
                         Attack(target);
-                        ShowBattleInfo(target, battleLog);
                         break;
                     }
                 case 1:
                     {
                         BattleSkillLogic(target);
-                        ShowBattleInfo(target, battleLog);
                         break;
                     }
                 case 2:
@@ -243,15 +241,13 @@ namespace newgame
 
         void BattleSkillLogic(Character target)
         {
-            battleLog[0] = "";
-            battleLog[1] = "";
             SkillType useSkill = ShowSkillList();
-            battleLog = UseAttackSkill(useSkill);
+            if (string.IsNullOrWhiteSpace(useSkill.name))
+            {
+                return;
+            }
 
-            ShowBattleInfo(target, battleLog);
-
-            // 스킬 특수효과 추가 처리
-            if (useSkill.name == null) return;
+            UseAttackSkill(useSkill);
 
             switch (useSkill.name)
             {


### PR DESCRIPTION
## Summary
- add reusable helpers to manage battle logs and render a unified combat layout
- update basic attacks and skill attacks to funnel through the shared battle message pipeline
- simplify player action flow to rely on the centralized battle display when attacking or using skills

## Testing
- dotnet build newgame.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c909f432288330bd598ac471c3b7a5