### PR TITLE
Unify battle messaging output

### DIFF
--- a/newgame/Battle.cs
+++ b/newgame/Battle.cs
@@ -21,6 +21,8 @@
 
             Character[] chars = new Character[] { player, monster };
 
+            Character.ResetBattleLog();
+
             player.isbattleRun = false;     // 필요시 monster도 false 초기화
 
             int current = 0; // 0: player, 1: monster

--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -190,13 +190,11 @@ namespace newgame
                 case 0:
                     {
                         Attack(target);
-                        ShowBattleInfo(target, battleLog);
                         break;
                     }
                 case 1:
                     {
                         BattleSkillLogic(target);
-                        ShowBattleInfo(target, battleLog);
                         break;
                     }
                 case 2:
@@ -243,16 +241,15 @@ namespace newgame
 
         void BattleSkillLogic(Character target)
         {
-            battleLog[0] = "";
-            battleLog[1] = "";
             SkillType useSkill = ShowSkillList();
+            if (string.IsNullOrWhiteSpace(useSkill.name))
+            {
+                return;
+            }
+
             battleLog = UseAttackSkill(useSkill);
 
-            ShowBattleInfo(target, battleLog);
-
             // 스킬 특수효과 추가 처리
-            if (useSkill.name == null) return;
-
             switch (useSkill.name)
             {
                 case "파이어볼":


### PR DESCRIPTION
## Summary
- centralize battle message formatting and logging inside `Character`
- ensure player actions rely on the shared log instead of duplicating output calls
- reset battle logs at battle start for clean and consistent displays

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c909f432288330bd598ac471c3b7a5