### PR TITLE
Adjust effect log display for sequential messages

### DIFF
--- a/newgame/Battle.cs
+++ b/newgame/Battle.cs
@@ -48,7 +48,11 @@
                 if (attacker.isbattleRun)
                     break;
 
-                // 2) 피격자가 죽었으면 즉시 종료
+                // 2) 행동자가 지속 피해 등으로 쓰러졌으면 종료
+                if (attacker.IsDead)
+                    break;
+
+                // 3) 피격자가 죽었으면 즉시 종료
                 if (defender.IsDead)
                     break;
 


### PR DESCRIPTION
## Summary
- queue skill tick messages per actor so over-time effects append to the existing action log instead of overwriting it
- render the battle log with multi-line arrow formatting and clear queued tick messages after the display
- flush queued damage-over-time messages before processing deaths triggered by tick resolution

## Testing
- `dotnet build newgame/newgame.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c91efa4ad48330a01cb832c333c4fb