### PR TITLE
Add boss battle skills

### DIFF
--- a/newgame/Boss.cs
+++ b/newgame/Boss.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace newgame
+{
+    internal class Boss : Monster
+    {
+        private readonly List<SkillType> availableSkills = new List<SkillType>();
+        private int bossKey;
+        private const int SkillUseChancePercent = 40;
+        private static readonly Random Randomizer = new Random();
+
+        public void StartBoss(int bossType)
+        {
+            bossKey = bossType;
+            base.Start(bossType);
+            LoadBossSkills();
+        }
+
+        void LoadBossSkills()
+        {
+            availableSkills.Clear();
+            foreach (SkillType skill in GameManager.Instance.GetBossSkills(bossKey))
+            {
+                if (!string.IsNullOrWhiteSpace(skill.name))
+                {
+                    availableSkills.Add(skill);
+                }
+            }
+        }
+
+        public override string[] Attack(Character target)
+        {
+            if (target != null && availableSkills.Count > 0)
+            {
+                if (Randomizer.Next(100) < SkillUseChancePercent)
+                {
+                    SkillType skill = availableSkills[Randomizer.Next(availableSkills.Count)];
+                    return UseAttackSkill(skill);
+                }
+            }
+
+            return base.Attack(target);
+        }
+    }
+}

--- a/newgame/Data/Boss.txt
+++ b/newgame/Data/Boss.txt
@@ -1,8 +1,10 @@
-﻿NAME : 스켈레톤
+NAME : 스켈레톤
 LEVEL : 2
 hp : 30
 ATK : 4
 DEF : 3
 EXP : 10
 COIN : 15
+SKILL : 파이어볼
+SKILL : 아쿠아 볼
 #

--- a/newgame/DataManager.cs
+++ b/newgame/DataManager.cs
@@ -210,46 +210,46 @@ namespace newgame
                 {
                     if (line == "#")
                     {
-                        // GameManager 에서 monster 리스트에 등록하기
+                        monStat.charType = CharType.MONSTER;
                         GameManager.Instance.SetMonsterInfo(monStat);
                         monStat = new Status();
                         continue;
                     }
 
-                    // 문자열 자르기 ( 해당 형식은 ":" 를 기준으로 문자열을 구분하고 있음 )
                     string[] curLine = line.Split(':');
-                    //if (curLine[0].Trim() == "TYPE")                 // Type 일 때
-                    //{
-                    //    monStat.charType = (CharType)Enum.Parse(typeof(CharType), curLine[1].Trim());
-                    //}
-                    if (curLine[0].Trim() == "NAME")           // NAME 일 때
+                    if (curLine.Length < 2)
                     {
-                        monStat.Name = curLine[1].Trim();
+                        continue;
                     }
-                    else if (curLine[0].Trim() == "LEVEL")           // STAT 일 때
+
+                    string key = curLine[0].Trim().ToUpperInvariant();
+                    string value = curLine[1].Trim();
+
+                    switch (key)
                     {
-                        monStat.level = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "hp")          // PRICE 일 때
-                    {
-                        monStat.Hp = int.Parse(curLine[1].Trim());
-                        monStat.maxHp = monStat.Hp;
-                    }
-                    else if (curLine[0].Trim() == "ATK")
-                    {
-                        monStat.ATK = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "DEF")
-                    {
-                        monStat.DEF = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "EXP")
-                    {
-                        monStat.exp = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "gold")
-                    {
-                        monStat.gold = int.Parse(curLine[1].Trim());
+                        case "NAME":
+                            monStat.Name = value;
+                            break;
+                        case "LEVEL":
+                            monStat.level = int.Parse(value);
+                            break;
+                        case "HP":
+                            monStat.Hp = int.Parse(value);
+                            monStat.maxHp = monStat.Hp;
+                            break;
+                        case "ATK":
+                            monStat.ATK = int.Parse(value);
+                            break;
+                        case "DEF":
+                            monStat.DEF = int.Parse(value);
+                            break;
+                        case "EXP":
+                            monStat.exp = int.Parse(value);
+                            break;
+                        case "GOLD":
+                        case "COIN":
+                            monStat.gold = int.Parse(value);
+                            break;
                     }
                 }
             }
@@ -290,51 +290,57 @@ namespace newgame
                 string[] lines = File.ReadAllLines(filePath);
 
                 Status BossStat = new Status();
+                List<string> skillNames = new List<string>();
 
                 foreach (string line in lines)
                 {
                     if (line == "#")
                     {
-                        // GameManager 에서 monster 리스트에 등록하기
-                        GameManager.Instance.SetBossInfo(BossStat);
+                        BossStat.charType = CharType.MONSTER;
+                        int bossKey = GameManager.Instance.SetBossInfo(BossStat);
+                        GameManager.Instance.SetBossSkills(bossKey, skillNames);
                         BossStat = new Status();
+                        skillNames = new List<string>();
                         continue;
                     }
 
-                    // 문자열 자르기 ( 해당 형식은 ":" 를 기준으로 문자열을 구분하고 있음 )
                     string[] curLine = line.Split(':');
-                    //if (curLine[0].Trim() == "TYPE")                 // Type 일 때
-                    //{
-                    //    monStat.charType = (CharType)Enum.Parse(typeof(CharType), curLine[1].Trim());
-                    //}
-                    if (curLine[0].Trim() == "NAME")           // NAME 일 때
+                    if (curLine.Length < 2)
                     {
-                        BossStat.Name = curLine[1].Trim();
+                        continue;
                     }
-                    else if (curLine[0].Trim() == "LEVEL")           // STAT 일 때
+
+                    string key = curLine[0].Trim().ToUpperInvariant();
+                    string value = curLine[1].Trim();
+
+                    switch (key)
                     {
-                        BossStat.level = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "hp")          // PRICE 일 때
-                    {
-                        BossStat.Hp = int.Parse(curLine[1].Trim());
-                        BossStat.maxHp = BossStat.Hp;
-                    }
-                    else if (curLine[0].Trim() == "ATK")
-                    {
-                        BossStat.ATK = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "DEF")
-                    {
-                        BossStat.DEF = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "EXP")
-                    {
-                        BossStat.exp = int.Parse(curLine[1].Trim());
-                    }
-                    else if (curLine[0].Trim() == "gold")
-                    {
-                        BossStat.gold = int.Parse(curLine[1].Trim());
+                        case "NAME":
+                            BossStat.Name = value;
+                            break;
+                        case "LEVEL":
+                            BossStat.level = int.Parse(value);
+                            break;
+                        case "HP":
+                            BossStat.Hp = int.Parse(value);
+                            BossStat.maxHp = BossStat.Hp;
+                            break;
+                        case "ATK":
+                            BossStat.ATK = int.Parse(value);
+                            break;
+                        case "DEF":
+                            BossStat.DEF = int.Parse(value);
+                            break;
+                        case "EXP":
+                            BossStat.exp = int.Parse(value);
+                            break;
+                        case "GOLD":
+                        case "COIN":
+                            BossStat.gold = int.Parse(value);
+                            break;
+                        case "SKILL":
+                            skillNames.Add(value);
+                            break;
                     }
                 }
             }

--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -301,9 +301,9 @@ namespace newgame
 
         void BossCreate()
         {
-            Monster monster = new Monster();
-            GameManager.Instance.monster = monster;
-            monster.Start(100 + floor);
+            Boss boss = new Boss();
+            GameManager.Instance.monster = boss;
+            boss.StartBoss(100 + floor);
             Battle battle = new Battle();
             battle.Start();
         }

--- a/newgame/GameManager.cs
+++ b/newgame/GameManager.cs
@@ -23,7 +23,8 @@ namespace newgame
 
         #region 몬스터 정보
         Dictionary<int, Status> monsterInfo = new Dictionary<int, Status>();
-        List<int> bossCount = new List<int>();
+        int bossCount = 1;
+        readonly Dictionary<int, List<string>> bossSkills = new Dictionary<int, List<string>>();
 
         public void SetMonsterInfo(Status _stat)
         {
@@ -31,10 +32,53 @@ namespace newgame
             monsterInfo.Add(key, _stat);
         }
 
-        public void SetBossInfo(Status _stat)
+        public int SetBossInfo(Status _stat)
         {
-            int key = 100 + (bossCount.Count);
+            int key = 100 + bossCount;
             monsterInfo.Add(key, _stat);
+            bossCount++;
+            return key;
+        }
+
+        public void SetBossSkills(int bossKey, IEnumerable<string> skillNames)
+        {
+            List<string> names = new List<string>();
+            foreach (string name in skillNames)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    names.Add(name.Trim());
+                }
+            }
+
+            if (names.Count > 0)
+            {
+                bossSkills[bossKey] = names;
+            }
+        }
+
+        public List<SkillType> GetBossSkills(int bossKey)
+        {
+            List<SkillType> results = new List<SkillType>();
+
+            if (bossSkills.TryGetValue(bossKey, out List<string>? names) && names != null)
+            {
+                foreach (string name in names)
+                {
+                    var skill = FindSkillByName(name);
+                    if (skill != null)
+                    {
+                        results.Add(skill.Value);
+                    }
+                }
+            }
+
+            if (results.Count == 0)
+            {
+                results.AddRange(GetSkills());
+            }
+
+            return results;
         }
 
         public Status GetMonsterStat(int _key)

--- a/newgame/Program.cs
+++ b/newgame/Program.cs
@@ -17,6 +17,7 @@ namespace newgame
         {
             DataManager.Instance.LoadAllEquipData();
             DataManager.Instance.LoadEnemyData();
+            DataManager.Instance.LoadBossData();
             DataManager.Instance.LoadDungeonMap();
             DataManager.Instance.LoadSkillData();
             GameManager.Instance.SetItemList();


### PR DESCRIPTION
## Summary
- load boss data during initialization and keep boss stats keyed by floor
- parse boss skill names from Boss.txt and expose them via GameManager
- introduce a Boss class that can cast skills and update the dungeon to spawn it

## Testing
- `dotnet build newgame/newgame.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9447468908330b83bdcbd61145e38