### PR TITLE
Refine boss spawning by floor

### DIFF
--- a/newgame/Boss.cs
+++ b/newgame/Boss.cs
@@ -10,10 +10,46 @@ namespace newgame
         private const int SkillUseChancePercent = 40;
         private static readonly Random Randomizer = new Random();
 
-        public void StartBoss(int bossType)
+        public void StartBoss(int floor)
         {
-            bossKey = bossType;
-            base.Start(bossType);
+            bossKey = floor;
+
+            Status bossStatus = GameManager.Instance.GetBossStat(floor);
+            string displayName = string.IsNullOrWhiteSpace(bossStatus.Name)
+                ? $"정체불명의 존재({floor}층)"
+                : bossStatus.Name;
+            bossStatus.Name = displayName;
+
+            MyStatus = bossStatus;
+            if (MyStatus.maxHp <= 0)
+            {
+                MyStatus.maxHp = Math.Max(MyStatus.Hp, 1);
+            }
+            if (MyStatus.Hp <= 0)
+            {
+                MyStatus.Hp = MyStatus.maxHp;
+            }
+            if (MyStatus.level <= 0)
+            {
+                MyStatus.level = 1;
+            }
+            if (MyStatus.ATK <= 0)
+            {
+                MyStatus.ATK = 1;
+            }
+            if (MyStatus.DEF < 0)
+            {
+                MyStatus.DEF = 0;
+            }
+
+            Console.Clear();
+            UiHelper.TxtOut(new string[]
+            {
+                $"{displayName}이(가) 나타났다!",
+                ""
+            });
+            UiHelper.WaitForInput();
+
             LoadBossSkills();
         }
 

--- a/newgame/DataManager.cs
+++ b/newgame/DataManager.cs
@@ -343,6 +343,13 @@ namespace newgame
                             break;
                     }
                 }
+
+                if (!string.IsNullOrWhiteSpace(BossStat.Name) || skillNames.Count > 0)
+                {
+                    BossStat.charType = CharType.MONSTER;
+                    int bossKey = GameManager.Instance.SetBossInfo(BossStat);
+                    GameManager.Instance.SetBossSkills(bossKey, skillNames);
+                }
             }
             catch (Exception ex)
             {

--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -303,7 +303,7 @@ namespace newgame
         {
             Boss boss = new Boss();
             GameManager.Instance.monster = boss;
-            boss.StartBoss(100 + floor);
+            boss.StartBoss(floor);
             Battle battle = new Battle();
             battle.Start();
         }


### PR DESCRIPTION
## Summary
- align boss registration with the dungeon floor and keep boss data separate from generic monster records
- spawn bosses through the new floor-based lookup, including defensive defaults when boss data is missing
- allow the boss loader to register the last entry even when the text file lacks a terminating separator

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9749e8d9c83309e844f58aa391b8a