### PR TITLE
Fix dungeon monsters persisting after player death

### DIFF
--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -32,6 +32,7 @@ namespace newgame
 
         // 맵 데이터 (2차원 배열)
         List<List<int>> map = new List<List<int>>();
+        bool playerDefeatedInDungeon = false;
         void LoadMapData(int number)
         {
             map = GameManager.Instance.GetDungeonMap(number);
@@ -74,6 +75,12 @@ namespace newgame
                 }
 
                 RoomEvent((RoomType)map[player.Y][player.X]);
+
+                if (playerDefeatedInDungeon)
+                {
+                    playerDefeatedInDungeon = false;
+                    return;
+                }
             }
 
         }
@@ -137,7 +144,20 @@ namespace newgame
                                 MonsterCreate();
                             }
                         }
-                        RoomDelete(); // 이벤트 처리 후 방 삭제
+                        bool playerDefeated = GameManager.Instance.player?.IsDead ?? false;
+                        bool monsterDefeated = GameManager.Instance.monster?.IsDead ?? false;
+
+                        if (playerDefeated)
+                        {
+                            GameManager.Instance.player.IsDead = false;
+                            playerDefeatedInDungeon = true;
+                            break;
+                        }
+
+                        if (monsterDefeated)
+                        {
+                            RoomDelete(); // 승리 시 방 삭제
+                        }
                         break;
                     }
                 #endregion


### PR DESCRIPTION
## Summary
- track player defeat state inside the dungeon loop so leaving the dungeon after death skips room cleanup
- ensure monster rooms are only cleared when the monster actually falls, preventing despawns when the player dies

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7a07d9a48330b51617179ee94eca