### PR TITLE
Improve manual DI safety and null handling

### DIFF
--- a/newgame/Battle.cs
+++ b/newgame/Battle.cs
@@ -16,8 +16,8 @@
 
         private static void Start_Battle()
         {
-            Character player = GameManager.Instance.player;
-            Character monster = GameManager.Instance.monster;
+            Character player = GameManager.Instance.RequirePlayer();
+            Character monster = GameManager.Instance.RequireMonster();
 
             Character[] chars = new Character[] { player, monster };
 

--- a/newgame/DataManager.cs
+++ b/newgame/DataManager.cs
@@ -63,7 +63,11 @@ namespace newgame
             if (File.Exists(path))
             {
                 string data = File.ReadAllText(path);
-                playerData = JsonConvert.DeserializeObject<Status>(data);
+                Status? deserialized = JsonConvert.DeserializeObject<Status>(data);
+                if (deserialized != null)
+                {
+                    playerData = deserialized;
+                }
             }
             #endregion
 

--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -134,6 +134,8 @@ namespace newgame
                             "도망 시도(35%)"
                         });
 
+                        Player activePlayer = GameManager.Instance.RequirePlayer();
+
                         if(select == 0)
                         {
                             UiHelper.WaitForInput("몬스터와의 전투를 시작합니다. [ENTER를 눌러 계속]");
@@ -149,16 +151,16 @@ namespace newgame
                             else
                             {
                                 UiHelper.WaitForInput("도망에 실패했습니다! 체력의 30%를 잃고 몬스터와 전투를 시작합니다!  [ENTER를 눌러 계속]");
-                                GameManager.Instance.player.MyStatus.Hp -= (int)(GameManager.Instance.player.MyStatus.maxHp * 0.3);
+                                activePlayer.MyStatus.Hp -= (int)(activePlayer.MyStatus.maxHp * 0.3);
                                 MonsterCreate();
                             }
                         }
-                        bool playerDefeated = GameManager.Instance.player?.IsDead ?? false;
+                        bool playerDefeated = activePlayer.IsDead;
                         bool monsterDefeated = GameManager.Instance.monster?.IsDead ?? false;
 
                         if (playerDefeated)
                         {
-                            GameManager.Instance.player.IsDead = false;
+                            activePlayer.IsDead = false;
                             playerDefeatedInDungeon = true;
                             break;
                         }

--- a/newgame/GameBuild.cs
+++ b/newgame/GameBuild.cs
@@ -261,17 +261,6 @@ namespace newgame
         }
         #endregion
 
-        private Player CurrentPlayer
-        {
-            get
-            {
-                if (_gameManager.Player == null)
-                {
-                    throw new InvalidOperationException("Player is not initialized.");
-                }
-
-                return _gameManager.Player;
-            }
-        }
+        private Player CurrentPlayer => _gameManager.RequirePlayer();
     }
 }

--- a/newgame/GameManager.cs
+++ b/newgame/GameManager.cs
@@ -24,7 +24,20 @@ namespace newgame
             get => player;
             set => player = value;
         }
+
+        public bool HasPlayer => player != null;
+
+        public Player RequirePlayer()
+        {
+            return player ?? throw new InvalidOperationException("Player has not been initialized yet.");
+        }
         public Monster? monster;
+        public bool HasMonster => monster != null;
+
+        public Monster RequireMonster()
+        {
+            return monster ?? throw new InvalidOperationException("Monster has not been initialized yet.");
+        }
 
         #region 몬스터 정보
         Dictionary<int, Status> monsterInfo = new Dictionary<int, Status>();
@@ -135,7 +148,7 @@ namespace newgame
 
         #region 아이템
         List<Item> items = new List<Item>();
-        public Item FindItem(ItemType _type)
+        public Item? FindItem(ItemType _type)
         {
             foreach (Item item in items)
             {
@@ -163,7 +176,7 @@ namespace newgame
         #region 장비 상태 확인
         List<Equipment> equips = new List<Equipment>();
         public List<Equipment> GetEquipment { get => Instance.equips; }
-        public Equipment FindEquipment(EquipType _type, int _id)
+        public Equipment? FindEquipment(EquipType _type, int _id)
         {
             foreach (Equipment equip in Instance.equips)
             {

--- a/newgame/Inventory.cs
+++ b/newgame/Inventory.cs
@@ -22,8 +22,8 @@ namespace newgame
             }
         }
 
-        private Dictionary<EquipType, Equipment> equips =
-            new Dictionary<EquipType, Equipment>()
+        private Dictionary<EquipType, Equipment?> equips =
+            new Dictionary<EquipType, Equipment?>()
             {
                 {EquipType.WEAPON, null! },
                 {EquipType.HELMET, null! },
@@ -81,7 +81,7 @@ namespace newgame
         public void SetEquip(EquipType _type, int _id)
         {
             //현제 착용하고 있는 장비를 확인하는 함수
-            Equipment item = GameManager.Instance.FindEquipment(_type, _id);//equipment 타입item변수에
+            Equipment? item = GameManager.Instance.FindEquipment(_type, _id);//equipment 타입item변수에
                                                                             //착용 가능한 장비의
                                                                             //타입과 id를 넣는다.
             if (item == null)
@@ -89,12 +89,15 @@ namespace newgame
                 return;
             }
 
+            Equipment equipItem = item;
+
             if (equips.ContainsKey(_type) == false)
             {
                 return;
             }
 
-            if (equips[_type] != null)
+            Equipment? currentlyEquipped = equips[_type];
+            if (currentlyEquipped != null)
             {
 
                 foreach (var can in canEquips)//그니깐 이건 리스트에 들어있는 모든 장비를 하나씩 꺼내서 can변수에 넣는 코드
@@ -102,27 +105,23 @@ namespace newgame
                     //canEquips 변수에 저장된 value 값과
                     //지금 착용하려는 아이템이 동일하다면,
                     //내가 현재 가지고 있는 장비 = 착용 가능한 장비
-                    if (can == item)
+                    if (can == equipItem)
                     {
-                        canEquips.Remove(item); //장비 꺼내기, 착용 가능한 장비에서 삭제
+                        canEquips.Remove(equipItem); //장비 꺼내기, 착용 가능한 장비에서 삭제
                         break;
                     }
                 }
                 //현제 착용하고 있는 장비를 다시 canEquips 에 저장
                 // 위에서 착용하지 않고 가지고 있던 장비를 꺼냈으니깐
-                canEquips.Add(equips[_type]);
+                canEquips.Add(currentlyEquipped);
             }
             //해당 Key 값이 item에 추가되게 한다
-            equips[_type] = item;
+            equips[_type] = equipItem;
         }
 
-        public Equipment GetEquip(EquipType _type)
+        public Equipment? GetEquip(EquipType _type)
         {
-            if (equips[_type] == null)
-            {
-                return null;
-            }
-            return equips[_type];
+            return equips.TryGetValue(_type, out Equipment? equip) ? equip : null;
         }
 
         #region 착용 장비 보이기
@@ -144,9 +143,9 @@ namespace newgame
                 }
 
                 string equipName = "없음";
-                if (equips.ContainsKey(type) && equips[type] != null)
+                if (equips.TryGetValue(type, out Equipment? equipped) && equipped != null)
                 {
-                    equipName = equips[type].GetEquipName;
+                    equipName = equipped.GetEquipName;
                 }
 
                 Console.WriteLine($"┃ {type,-6} : {equipName,-14}");
@@ -166,7 +165,8 @@ namespace newgame
             int temp = idx - 1;
             if (temp >= 0 && temp < canEquips.Count)
             {
-                GameManager.Instance.player.MyStatus.gold += canEquips[idx - 1].GetPrice;
+                Player player = GameManager.Instance.RequirePlayer();
+                player.MyStatus.gold += canEquips[idx - 1].GetPrice;
                 canEquips.RemoveAt(idx - 1);
                 return;
             }
@@ -275,7 +275,8 @@ namespace newgame
 
             if (item.IsPersistent())
             {
-                GameManager.Instance.player.AddEffect(item);
+                Player player = GameManager.Instance.RequirePlayer();
+                player.AddEffect(item);
             }
 
             slot.Decrease(1);

--- a/newgame/Lobby.cs
+++ b/newgame/Lobby.cs
@@ -16,6 +16,8 @@ namespace newgame
 
             Console.WriteLine("\t[마을]");
 
+            Player player = GameManager.Instance.RequirePlayer();
+
             int menusel = UiHelper.SelectMenu([
                 "상태창 보기",
                 "인벤토리 보기",
@@ -33,7 +35,7 @@ namespace newgame
                     {
                         Console.Clear();
                         Console.WriteLine("[ 상태창 ] \r");
-                        GameManager.Instance.player.ShowStat();
+                        player.ShowStat();
                         Console.WriteLine("[Enter]를 눌러 돌아가기");
                         Console.ReadKey();
                         Console.Clear();
@@ -43,7 +45,7 @@ namespace newgame
                     {
                         Console.Clear();
                         Console.WriteLine("[ 인벤토리 ] \r");
-                        GameManager.Instance.player.MyStatus.ShowInventory();
+                        player.MyStatus.ShowInventory();
                         break;
                     }
                 case 2:
@@ -82,7 +84,7 @@ namespace newgame
                 case 6:
                     {
                         Console.Clear();
-                        DataManager.Instance.Save(GameManager.Instance.player.MyStatus);
+                        DataManager.Instance.Save(player.MyStatus);
                         UiHelper.WaitForInput("게임 저장됨. (SHIFT를 눌러 계속)");
                         break;
                     }

--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -18,7 +18,7 @@ namespace newgame
         #region 플레이어 생성
         void Create()
         {
-            GameManager.Instance.player.MyStatus = new Status();
+            MyStatus = new Status();
             MyStatus.charType = CharType.PLAYER;
             SetPlayerStarterItem();
             SetPlayerStarterSkill();
@@ -30,7 +30,7 @@ namespace newgame
         #region 저장된 플레이어 불러오기
         public void Load()
         {
-            GameManager.Instance.player.MyStatus = DataManager.Instance.Load();
+            MyStatus = DataManager.Instance.Load();
         }
         #endregion
 

--- a/newgame/Shop.cs
+++ b/newgame/Shop.cs
@@ -76,9 +76,11 @@ namespace newgame
                 return;
             }
 
-            if (GameManager.Instance.player.MyStatus.gold >= items[menuSelect].GetPrice)
+            Player player = GameManager.Instance.RequirePlayer();
+
+            if (player.MyStatus.gold >= items[menuSelect].GetPrice)
             {
-                GameManager.Instance.player.MyStatus.gold -= items[menuSelect].GetPrice;
+                player.MyStatus.gold -= items[menuSelect].GetPrice;
                 Inventory.Instance.AddEquip(items[menuSelect]);
 
                 UiHelper.TxtOut(["", $"{items[menuSelect].GetEquipName} 구매 완료",""]);
@@ -167,12 +169,12 @@ namespace newgame
             }
 
             Console.Write("입력 : ");
-            string input = Console.ReadLine();
+            string? input = Console.ReadLine();
             BuyConsumableItem(input);
         }
 
         #region 아이템 관련 추가
-        void BuyConsumableItem(string _idx)
+        void BuyConsumableItem(string? _idx)
         {
             // _idx 문자열이 비어있다면
             if (string.IsNullOrEmpty(_idx))
@@ -183,7 +185,12 @@ namespace newgame
                 return;
             }
 
-            int idx = int.Parse(_idx);
+            if (!int.TryParse(_idx, out int idx))
+            {
+                Console.WriteLine("잘못된 입력입니다.");
+                ShowBuyConsumableItemMenu();
+                return;
+            }
             // idx = 1 ~ 5 범위가 아닌 경우에는 함수 종료
             if (idx <= (int)ItemType.NONE || idx >= Enum.GetValues(typeof(ItemType)).Length)
             {
@@ -194,11 +201,18 @@ namespace newgame
             }
 
             // 구매 진행
-            Item item = GameManager.Instance.FindItem((ItemType)idx);
-            if (GameManager.Instance.player.MyStatus.gold >= item.ItemPrice)
+            Item? item = GameManager.Instance.FindItem((ItemType)idx);
+            if (item == null)
+            {
+                Console.WriteLine("해당 아이템을 찾을 수 없습니다.");
+                return;
+            }
+
+            Player player = GameManager.Instance.RequirePlayer();
+            if (player.MyStatus.gold >= item.ItemPrice)
             {
                 // 돈이 있네?
-                GameManager.Instance.player.MyStatus.gold -= item.ItemPrice;
+                player.MyStatus.gold -= item.ItemPrice;
                 Inventory.Instance.AddItem(item);
 
                 ShowMenu();

--- a/newgame/Skills.cs
+++ b/newgame/Skills.cs
@@ -95,7 +95,8 @@ namespace newgame
                 canUseSkillList.Add($"{skill.name} --- 마나 사용량 : {skill.skillMana}{extra}");
             }
             canUseSkillList.Add("취소");
-            Console.WriteLine($"현제 마나 : {GameManager.Instance.player.MyStatus.mp}/{GameManager.Instance.player.MyStatus.maxMp}");
+            Player player = GameManager.Instance.RequirePlayer();
+            Console.WriteLine($"현제 마나 : {player.MyStatus.mp}/{player.MyStatus.maxMp}");
             int selected = UiHelper.SelectMenu(canUseSkillList.ToArray());
             if (selected >= 0 && selected < canUseSkill.Count)
             {

--- a/newgame/Smithy.cs
+++ b/newgame/Smithy.cs
@@ -15,7 +15,7 @@
             Console.WriteLine("2. 이전으로");
             Console.Write("선택: ");
 
-            string input = Console.ReadLine();
+            string? input = Console.ReadLine();
 
             if (input != "1")
             {
@@ -29,11 +29,12 @@
 
         void EquipUpgrade()
         {
-            Equipment equip = null;
+            Equipment? equip = null;
             for (int i = 1; i < (int)EquipType.MAX; i++)
             {
                 equip = Inventory.Instance.GetEquip((EquipType)i);
-                Console.WriteLine($"[{i}] {equip.GetEquipName}");
+                string equipName = equip?.GetEquipName ?? "없음";
+                Console.WriteLine($"[{i}] {equipName}");
             }
 
             Console.WriteLine("입력 : ");
@@ -47,6 +48,13 @@
             }
 
             equip = Inventory.Instance.GetEquip((EquipType)idx);
+            if (equip == null)
+            {
+                Console.WriteLine("장비가 없습니다.");
+                UiHelper.WaitForInput("[ENTER]를 눌러 계속");
+                return;
+            }
+
             equip.Upgrade();
         }
     }

--- a/newgame/Tavern.cs
+++ b/newgame/Tavern.cs
@@ -90,7 +90,8 @@ namespace newgame
         #region 숙박
         void SleepTavern()
         {
-            var playerstat = GameManager.Instance.player.MyStatus;
+            Player player = GameManager.Instance.RequirePlayer();
+            var playerstat = player.MyStatus;
             Console.Clear();
 
             while (true)
@@ -147,7 +148,8 @@ namespace newgame
         #region 여관 상점
         void TavernShop()
         {
-            var playerstat = GameManager.Instance.player.MyStatus;
+            Player player = GameManager.Instance.RequirePlayer();
+            var playerstat = player.MyStatus;
 
             Console.Clear();
 
@@ -194,7 +196,8 @@ namespace newgame
 
         void TavernGambling_Betting()
         {
-            var playerstat = GameManager.Instance.player.MyStatus;
+            Player player = GameManager.Instance.RequirePlayer();
+            var playerstat = player.MyStatus;
             Console.Clear();
 
             int sel = UiHelper.SelectMenu(["골드 배팅",
@@ -289,7 +292,8 @@ namespace newgame
                 Console.WriteLine("아쉽게도 당첨되지 않았습니다.");
             }
 
-            var playerstat = GameManager.Instance.player.MyStatus;
+            Player player = GameManager.Instance.RequirePlayer();
+            var playerstat = player.MyStatus;
             if (reward > 0)
             {
                 playerstat.gold += (int)reward;


### PR DESCRIPTION
## Summary
- harden the composition root by exposing GameManager helpers like `RequirePlayer` and `RequireMonster`, then route lobby, shop, tavern, dungeon and battle flows through them
- guard `Character` status access with explicit null checks, rewrite attack/skill paths to use validated status references and clean up manual DI side effects in `Player`
- update inventory, smithy, shop and data loading code to cope with missing data safely so nullable analysis builds cleanly

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68caa6415b04833093d1408a4b594477