### PR TITLE
Refactor active item effect handling into manager

### DIFF
--- a/newgame/Inventory.cs
+++ b/newgame/Inventory.cs
@@ -266,7 +266,7 @@ namespace newgame
             Console.WriteLine("해당 아이템이 없습니다.");
         }
 
-        public void UseItem(int index)
+        public void UseItem(int index, ActiveItemEffectManager effectManager)
         {
             var slot = items[index - 1];
             var item = slot.Item;
@@ -275,8 +275,7 @@ namespace newgame
 
             if (item.IsPersistent())
             {
-                Player player = GameManager.Instance.RequirePlayer();
-                player.AddEffect(item);
+                effectManager.AddEffect(item);
             }
 
             slot.Decrease(1);

--- a/newgame/items/ActiveItemEffectManager.cs
+++ b/newgame/items/ActiveItemEffectManager.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+
+namespace newgame
+{
+    internal interface IActiveItemEffectNotifier
+    {
+        void WriteLine(string message);
+    }
+
+    internal sealed class ConsoleActiveItemEffectNotifier : IActiveItemEffectNotifier
+    {
+        public void WriteLine(string message)
+        {
+            Console.WriteLine(message);
+        }
+    }
+
+    internal class ActiveItemEffectManager
+    {
+        private readonly List<ActiveItemEffect> activeEffects = new();
+        private readonly IActiveItemEffectNotifier notifier;
+
+        public ActiveItemEffectManager(IActiveItemEffectNotifier? notifier = null)
+        {
+            this.notifier = notifier ?? new ConsoleActiveItemEffectNotifier();
+        }
+
+        public void AddEffect(Item item)
+        {
+            bool isFound = false;
+
+            foreach (ActiveItemEffect effect in activeEffects)
+            {
+                if (effect.ItemType == item.ItemType)
+                {
+                    effect.RemainingTurn += item.ItemUsedCount;
+                    effect.TotalBonus += item.ItemStatus;
+
+                    notifier.WriteLine($"{item.ItemType} 효과가 누적되었습니다! → +{item.ItemStatus} / 남은 턴: {effect.RemainingTurn} (소모 시점: {effect.ConsumeType})");
+                    isFound = true;
+                    break;
+                }
+            }
+
+            if (!isFound)
+            {
+                ActiveItemEffect newEffect = new ActiveItemEffect(item);
+                activeEffects.Add(newEffect);
+
+                notifier.WriteLine($"{item.ItemType} 효과가 새롭게 적용되었습니다! → +{item.ItemStatus} / {item.ItemUsedCount}턴 간 지속 (소모 시점: {newEffect.ConsumeType})");
+            }
+        }
+
+        public void OnBattleStart()
+        {
+            for (int i = activeEffects.Count - 1; i >= 0; i--)
+            {
+                ActiveItemEffect effect = activeEffects[i];
+                if (effect.ConsumeType == ConsumeType.BattleStart)
+                {
+                    effect.RemainingTurn--;
+                    notifier.WriteLine($"{effect.ItemType} 효과가 1턴 차감되었습니다. → 남은 턴: {effect.RemainingTurn}");
+
+                    if (effect.RemainingTurn <= 0)
+                    {
+                        notifier.WriteLine($"{effect.ItemType} 효과가 종료되었습니다. (전투 시작 시 차감)");
+                        activeEffects.RemoveAt(i);
+                    }
+                }
+            }
+        }
+
+        public void OnTurnPassed()
+        {
+            for (int i = activeEffects.Count - 1; i >= 0; i--)
+            {
+                ActiveItemEffect effect = activeEffects[i];
+                if (effect.ConsumeType == ConsumeType.PerTurn)
+                {
+                    effect.RemainingTurn--;
+                    notifier.WriteLine($"{effect.ItemType} 효과가 1턴 차감되었습니다. → 남은 턴: {effect.RemainingTurn}");
+
+                    if (effect.RemainingTurn <= 0)
+                    {
+                        notifier.WriteLine($"{effect.ItemType} 효과가 종료되었습니다. (턴 경과로 차감)");
+                        activeEffects.RemoveAt(i);
+                    }
+                }
+            }
+        }
+
+        public int GetTotalBonus(ItemType effectType)
+        {
+            int total = 0;
+
+            foreach (ActiveItemEffect effect in activeEffects)
+            {
+                if (effect.ItemType == effectType)
+                {
+                    total += effect.TotalBonus;
+                }
+            }
+
+            return total;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an ActiveItemEffectManager that owns effect state, console output, and exposes notifier injection for tests
- update Character to hold the manager, provide constructors for injecting it, and delegate item-effect methods through the manager
- change Inventory.UseItem so that persistent items update the shared manager instead of directly mutating characters

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68cb619bd7788330a0c85df848495931