### PR TITLE
Add minimal player class assignment support

### DIFF
--- a/newgame/GameBuild.cs
+++ b/newgame/GameBuild.cs
@@ -182,10 +182,25 @@ namespace newgame
 
             player.Initializer.SetDefStat(atk, hp, def, mp);
 
+            AssignInitialClass(player);
+
             player.Initializer.ShowStat();
             Console.WriteLine("[Enter]를 눌러 계속");
             Console.ReadKey();
         }
+        private void AssignInitialClass(Player player)
+        {
+            var classes = _gameManager.GetPlayerClasses();
+            if (classes.Count == 0)
+            {
+                return;
+            }
+
+            CharacterClassType chosen = classes[0];
+            player.AssignClass(chosen);
+            Console.WriteLine($"기본 직업 [{chosen.name}] 이(가) 적용되었습니다.");
+        }
+
         #endregion
 
         #region 랜덤 스텟 설정

--- a/newgame/GameManager.cs
+++ b/newgame/GameManager.cs
@@ -518,6 +518,21 @@ namespace newgame
         /// </summary>
         public IReadOnlyList<CharacterClassType> GetPlayerClasses() => Jobs.AsReadOnly();
 
+        public bool TryGetPlayerClass(string className, out CharacterClassType classType)
+        {
+            foreach (CharacterClassType job in Jobs)
+            {
+                if (string.Equals(job.name, className, StringComparison.OrdinalIgnoreCase))
+                {
+                    classType = job;
+                    return true;
+                }
+            }
+
+            classType = default;
+            return false;
+        }
+
         /// <summary>
         /// 직업명으로 스킬들을 조회한다. 이름이 매칭되는 스킬만 반환한다.
         /// </summary>

--- a/newgame/Status.cs
+++ b/newgame/Status.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Net.NetworkInformation;
 using static newgame.UiHelper;
 
@@ -220,6 +221,28 @@ namespace newgame
             //int idx = 0;
             //int.TryParse(Console.ReadLine(), out idx);
             Inventory.Instance.SetEquip(sel + 1);
+        }
+
+        public void ApplyClass(CharacterClassType classType)
+        {
+            if (string.IsNullOrWhiteSpace(classType.name))
+            {
+                throw new ArgumentException("Class name cannot be empty.", nameof(classType));
+            }
+
+            ClassName = classType.name;
+
+            atk += classType.atk;
+            def += classType.def;
+
+            maxHp += classType.hp;
+            Hp = maxHp;
+
+            maxMp += classType.mp;
+            mp = maxMp;
+
+            CriticalChance += classType.CC;
+            CriticalDamage += classType.CD;
         }
 
         #region 직업 추가를 위한 플래이어에게만 className 추가


### PR DESCRIPTION
## Summary
- add a status helper to apply class-based stat bonuses
- allow the player to be assigned a class, reuse saved class info, and refresh skills
- wire class lookup into the game build so a default class is applied when a new game starts

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d0d2d5ca04833084a8d87d28c4cb5c