### PR TITLE
Handle dungeon defeat with explicit respawn flow

### DIFF
--- a/newgame/Character.cs
+++ b/newgame/Character.cs
@@ -227,13 +227,6 @@ namespace newgame
                 Console.WriteLine("전투에서 패배했다..");
                 Console.WriteLine("눈앞이 깜깜해졌다.");
                 Thread.Sleep(2000);
-
-                MyStatus.Hp = Math.Max(1, MyStatus.MaxHp / 2);
-                MyStatus.Mp = MyStatus.MaxMp;
-                IsDead = false;
-
-                Tavern tavern = new Tavern();
-                tavern.Start();
             }
         }
         #endregion

--- a/newgame/Dungeon.cs
+++ b/newgame/Dungeon.cs
@@ -65,7 +65,8 @@ namespace newgame
                 // 키 입력 받기
                 ConsoleKeyInfo key = Console.ReadKey(true);
                 
-                if (!GameManager.Instance.player.IsDead)
+                Player? activePlayerForCleanup = GameManager.Instance.Player;
+                if (activePlayerForCleanup != null && !activePlayerForCleanup.IsDead)
                 {
                     RoomDelete();
                 }
@@ -92,6 +93,10 @@ namespace newgame
                 {
                     GameManager.Instance.UpdateDungeonMap(floor, map);
                     UiHelper.WaitForInput("던전에서 패배하여 마을로 돌아갑니다. [ENTER를 눌러 계속]");
+
+                    Player? activePlayer = GameManager.Instance.Player;
+                    activePlayer?.RespawnAtTavern();
+
                     player.X = 1; // 플레이어 위치 초기화
                     player.Y = 1; // 플레이어 위치 초기화
                     playerDefeatedInDungeon = false;
@@ -167,7 +172,6 @@ namespace newgame
 
                         if (playerDefeated)
                         {
-                            activePlayer.IsDead = false;
                             playerDefeatedInDungeon = true;
                             break;
                         }

--- a/newgame/Player.cs
+++ b/newgame/Player.cs
@@ -120,6 +120,18 @@ namespace newgame
             RestoreClassState();
         }
 
+        #region 패배 후 복구
+        public void RespawnAtTavern()
+        {
+            MyStatus.Hp = Math.Max(1, MyStatus.MaxHp / 2);
+            MyStatus.Mp = MyStatus.MaxMp;
+            IsDead = false;
+
+            Tavern tavern = new Tavern();
+            tavern.Start();
+        }
+        #endregion
+
         #region 저장된 플레이어 불러오기
         public void Load()
         {


### PR DESCRIPTION
## Summary
- remove the immediate revive from `Character.Dead` so dungeon defeat can be detected
- add `Player.RespawnAtTavern` to restore HP/MP, reset the death flag, and route the player back to the tavern
- update dungeon defeat handling to call the new respawn method and guard cleanup when the player reference is missing

## Testing
- dotnet build newgame/newgame.csproj

------
https://chatgpt.com/codex/tasks/task_e_68da0e2e164c8330930b709d93342dbb